### PR TITLE
[BUG] 26 bug attributeerror str object has no attribute get

### DIFF
--- a/VCE/delete_device.py
+++ b/VCE/delete_device.py
@@ -181,7 +181,10 @@ def run_thread_with_rate_limit(limited_threads, rate_limit=2):
 
 
 def login_and_get_tokens(
-    login_session: requests.Session, username=USERNAME, password=PASSWORD, org_id=ORG_ID
+    login_session: requests.Session,
+    username=USERNAME,
+    password=PASSWORD,
+    org_id=ORG_ID,
 ):
     """
     Initiates a Command session with the given user credentials and Verkada
@@ -231,7 +234,12 @@ def login_and_get_tokens(
         ) from e
 
 
-def logout(logout_session: requests.Session, x_verkada_token, x_verkada_auth, org_id=ORG_ID):
+def logout(
+    logout_session: requests.Session,
+    x_verkada_token,
+    x_verkada_auth,
+    org_id=ORG_ID,
+):
     """
     Logs the Python script out of Command to prevent orphaned sessions.
 
@@ -273,7 +281,9 @@ def logout(logout_session: requests.Session, x_verkada_token, x_verkada_auth, or
 ##############################################################################
 
 
-def delete_cameras(camera_session: requests.Session, x_verkada_token, usr, org_id=ORG_ID):
+def delete_cameras(
+    camera_session: requests.Session, x_verkada_token, usr, org_id=ORG_ID
+):
     """
     Deletes all cameras from a Verkada organization.
 
@@ -518,7 +528,11 @@ def delete_sensors(
 
 
 def delete_panels(
-    x_verkada_token, x_verkada_auth, usr, ac_session: requests.Session, org_id=ORG_ID
+    x_verkada_token,
+    x_verkada_auth,
+    usr,
+    ac_session: requests.Session,
+    org_id=ORG_ID,
 ):
     """
     Deletes all access control panels from a Verkada organization.
@@ -594,7 +608,11 @@ def delete_panels(
 
 
 def delete_intercom(
-    x_verkada_token, usr, device_id, icom_session: requests.Session, org_id=ORG_ID
+    x_verkada_token,
+    usr,
+    device_id,
+    icom_session: requests.Session,
+    org_id=ORG_ID,
 ):
     """
     Deletes all Intercoms from a Verkada organization.
@@ -632,7 +650,11 @@ def delete_intercom(
 
 
 def delete_environmental(
-    x_verkada_token, x_verkada_auth, usr, sv_session: requests.Session, org_id=ORG_ID
+    x_verkada_token,
+    x_verkada_auth,
+    usr,
+    sv_session: requests.Session,
+    org_id=ORG_ID,
 ):
     """
     Deletes all environmental sensors from a Verkada organization.
@@ -693,7 +715,11 @@ def delete_environmental(
 
 
 def delete_guest(
-    x_verkada_token, x_verkada_auth, usr, guest_session: requests.Session, org_id=ORG_ID
+    x_verkada_token,
+    x_verkada_auth,
+    usr,
+    guest_session: requests.Session,
+    org_id=ORG_ID,
 ):
     """
     Deletes all Guest devices from a Verkada organization.
@@ -791,7 +817,9 @@ def delete_guest(
         raise custom_exceptions.APIExceptionHandler(e, response, ptype) from e
 
 
-def delete_acls(x_verkada_token, usr, acl_session: requests.Session, org_id=ORG_ID):
+def delete_acls(
+    x_verkada_token, usr, acl_session: requests.Session, org_id=ORG_ID
+):
     """
     Deletes all access control levels from a Verkada organization.
 
@@ -856,7 +884,9 @@ def delete_acls(x_verkada_token, usr, acl_session: requests.Session, org_id=ORG_
         raise custom_exceptions.APIExceptionHandler(e, response, ptype)
 
 
-def delete_desk_station(x_verkada_token, usr, ds_session: requests.Session, org_id=ORG_ID):
+def delete_desk_station(
+    x_verkada_token, usr, ds_session: requests.Session, org_id=ORG_ID
+):
     """
     Deletes all Guest devices from a Verkada organization.
 

--- a/VCE/delete_device.py
+++ b/VCE/delete_device.py
@@ -206,7 +206,7 @@ def login_and_get_tokens(
     login_data = {
         "email": username,
         "password": password,
-        "otp": generate_totp(getenv("boi_totp")),
+        "otp": generate_totp(getenv("")),
         "org_id": org_id,
     }
 

--- a/VCE/delete_device.py
+++ b/VCE/delete_device.py
@@ -17,10 +17,10 @@ import colorama
 import requests
 from colorama import Fore, Style
 from dotenv import load_dotenv
+from QoL.verkada_totp import generate_totp
 
-import custom_exceptions
+import QoL.custom_exceptions as custom_exceptions
 import VCE.gather_devices as gather_devices
-from verkada_totp import generate_totp
 
 colorama.init(autoreset=True)  # Initialize colorized output
 
@@ -181,12 +181,14 @@ def run_thread_with_rate_limit(limited_threads, rate_limit=2):
 
 
 def login_and_get_tokens(
-    login_session, username=USERNAME, password=PASSWORD, org_id=ORG_ID
+    login_session: requests.Session, username=USERNAME, password=PASSWORD, org_id=ORG_ID
 ):
     """
     Initiates a Command session with the given user credentials and Verkada
     organization ID.
 
+    :param login_session: The request session to use to make the call with.
+    :type login_session: requests.Session
     :param username: A Verkada user's username to be used during the login.
     :type username: str, optional
     :param password: A Verkada user's password used during the login process.
@@ -201,7 +203,7 @@ def login_and_get_tokens(
     login_data = {
         "email": username,
         "password": password,
-        "otp": generate_totp(getenv("lab_totp")),
+        "otp": generate_totp(getenv("boi_totp")),
         "org_id": org_id,
     }
 
@@ -229,10 +231,12 @@ def login_and_get_tokens(
         ) from e
 
 
-def logout(logout_session, x_verkada_token, x_verkada_auth, org_id=ORG_ID):
+def logout(logout_session: requests.Session, x_verkada_token, x_verkada_auth, org_id=ORG_ID):
     """
     Logs the Python script out of Command to prevent orphaned sessions.
 
+    :param logout_session: The request session to use to make the call with.
+    :type logout_session: requests.Session
     :param x_verkada_token: The csrf token for a valid, authenticated session.
     :type x_verkada_token: str
     :param x_verkada_auth: The authenticated user token for a valid Verkada
@@ -269,10 +273,12 @@ def logout(logout_session, x_verkada_token, x_verkada_auth, org_id=ORG_ID):
 ##############################################################################
 
 
-def delete_cameras(camera_session, x_verkada_token, usr, org_id=ORG_ID):
+def delete_cameras(camera_session: requests.Session, x_verkada_token, usr, org_id=ORG_ID):
     """
     Deletes all cameras from a Verkada organization.
 
+    :param camera_session: The request session to use to make the call with.
+    :type camera_session: requests.Session
     :param x_verkada_token: The csrf token for a valid, authenticated session.
     :type x_verkada_token: str
     :param x_verkada_auth: The authenticated user token for a valid Verkada
@@ -281,6 +287,8 @@ def delete_cameras(camera_session, x_verkada_token, usr, org_id=ORG_ID):
     :param usr: The user ID of the authenticated user for a valid Verkada
     Command session.
     :type usr: str
+    :param org_id: The organization ID for the targeted Verkada org.
+    :type org_id: str, optional
     """
     headers = {
         "x-verkada-organization-id": org_id,
@@ -327,6 +335,10 @@ def delete_sensors(
     :param usr: The user ID of the authenticated user for a valid Verkada
     Command session.
     :type usr: str
+    :param alarm_session: The request session to use to make the call with.
+    :type alarm_session: requests.Session
+    :param org_id: The organization ID for the targeted Verkada org.
+    :type org_id: str, optional
     """
     alarm_threads = []
 
@@ -398,7 +410,7 @@ def delete_sensors(
                             APANEL_DECOM, headers=headers, json=data
                         )
 
-                        if response.status == 200:
+                        if response.status_code == 200:
                             log.debug(
                                 "%sKeypad deleted successfully%s",
                                 Fore.GREEN,
@@ -506,7 +518,7 @@ def delete_sensors(
 
 
 def delete_panels(
-    x_verkada_token, x_verkada_auth, usr, ac_session, org_id=ORG_ID
+    x_verkada_token, x_verkada_auth, usr, ac_session: requests.Session, org_id=ORG_ID
 ):
     """
     Deletes all access control panels from a Verkada organization.
@@ -516,6 +528,10 @@ def delete_panels(
     :param x_verkada_auth: The authenticated user token for a valid Verkada
     session.
     :type x_verkada_auth: str
+    :param ac_session: The request session to use to make the call with.
+    :type ac_session: requests.Session
+    :param org_id: The organization ID for the targeted Verkada org.
+    :type org_id: str, optional
     """
     exempt = []
 
@@ -578,7 +594,7 @@ def delete_panels(
 
 
 def delete_intercom(
-    x_verkada_token, usr, device_id, icom_session, org_id=ORG_ID
+    x_verkada_token, usr, device_id, icom_session: requests.Session, org_id=ORG_ID
 ):
     """
     Deletes all Intercoms from a Verkada organization.
@@ -588,6 +604,10 @@ def delete_intercom(
     :param x_verkada_auth: The authenticated user token for a valid Verkada
     session.
     :type x_verkada_auth: str
+    :param icom_session: The request session to use to make the call with.
+    :type icom_session: requests.Session
+    :param org_id: The organization ID for the targeted Verkada org.
+    :type org_id: str, optional
     """
     headers = {
         "x-verkada-organization-id": org_id,
@@ -612,7 +632,7 @@ def delete_intercom(
 
 
 def delete_environmental(
-    x_verkada_token, x_verkada_auth, usr, sv_session, org_id=ORG_ID
+    x_verkada_token, x_verkada_auth, usr, sv_session: requests.Session, org_id=ORG_ID
 ):
     """
     Deletes all environmental sensors from a Verkada organization.
@@ -622,6 +642,10 @@ def delete_environmental(
     :param x_verkada_auth: The authenticated user token for a valid Verkada
     session.
     :type x_verkada_auth: str
+    :param sv_session: The request session to use to make the call with.
+    :type sv_session: requests.Session
+    :param org_id: The organization ID for the targeted Verkada org.
+    :type org_id: str, optional
     """
     params = {"organizationId": org_id}
 
@@ -669,7 +693,7 @@ def delete_environmental(
 
 
 def delete_guest(
-    x_verkada_token, x_verkada_auth, usr, guest_session, org_id=ORG_ID
+    x_verkada_token, x_verkada_auth, usr, guest_session: requests.Session, org_id=ORG_ID
 ):
     """
     Deletes all Guest devices from a Verkada organization.
@@ -679,6 +703,10 @@ def delete_guest(
     :param x_verkada_auth: The authenticated user token for a valid Verkada
     session.
     :type x_verkada_auth: str
+    :param guest_session: The request session to use to make the call with.
+    :type guest_session: requests.Session
+    :param org_id: The organization ID for the targeted Verkada org.
+    :type org_id: str, optional
     """
     params = {"organizationId": org_id}
 
@@ -763,7 +791,7 @@ def delete_guest(
         raise custom_exceptions.APIExceptionHandler(e, response, ptype) from e
 
 
-def delete_acls(x_verkada_token, usr, acl_session, org_id=ORG_ID):
+def delete_acls(x_verkada_token, usr, acl_session: requests.Session, org_id=ORG_ID):
     """
     Deletes all access control levels from a Verkada organization.
 
@@ -772,6 +800,10 @@ def delete_acls(x_verkada_token, usr, acl_session, org_id=ORG_ID):
     :param x_verkada_auth: The authenticated user token for a valid Verkada
     session.
     :type x_verkada_auth: str
+    :param acl_session: The request session to use to make the call with.
+    :type acl_session: requests.Session
+    :param org_id: The organization ID for the targeted Verkada org.
+    :type org_id: str, optional
     """
 
     def find_schedule_by_id(schedule_id, schedules):
@@ -824,7 +856,7 @@ def delete_acls(x_verkada_token, usr, acl_session, org_id=ORG_ID):
         raise custom_exceptions.APIExceptionHandler(e, response, ptype)
 
 
-def delete_desk_station(x_verkada_token, usr, ds_session, org_id=ORG_ID):
+def delete_desk_station(x_verkada_token, usr, ds_session: requests.Session, org_id=ORG_ID):
     """
     Deletes all Guest devices from a Verkada organization.
 
@@ -833,6 +865,10 @@ def delete_desk_station(x_verkada_token, usr, ds_session, org_id=ORG_ID):
     :param x_verkada_auth: The authenticated user token for a valid Verkada
     session.
     :type x_verkada_auth: str
+    :param ds_session: The request session to use to make the call with.
+    :type ds_session: requests.Session
+    :param org_id: The organization ID for the targeted Verkada org.
+    :type org_id: str, optional
     """
     headers = {
         "x-verkada-organization-id": org_id,
@@ -874,6 +910,7 @@ def delete_desk_station(x_verkada_token, usr, ds_session, org_id=ORG_ID):
 
 
 if __name__ == "__main__":
+    csrf_token, user_token, user_id = None, None, None
     start_run_time = time.time()  # Start timing the script
     with requests.Session() as session:
         try:

--- a/VCE/gather_devices.py
+++ b/VCE/gather_devices.py
@@ -211,7 +211,7 @@ def list_cameras(api_key, camera_session: requests.Session):
     :param api_key: The API key generated from the organization to target.
     :type api_key: str
     :param camera_session: The request session to use to make the call with.
-    :type camera_session: object
+    :type camera_session: requests.Session
     :return: Returns a list of all camera device IDs found inside of a Verkada
     organization.
     :rtype: list

--- a/VCE/gather_devices.py
+++ b/VCE/gather_devices.py
@@ -130,7 +130,7 @@ def login_and_get_tokens(
     login_data = {
         "email": username,
         "password": password,
-        "otp": generate_totp(getenv("lab_totp")),
+        "otp": generate_totp(getenv("")),
         "org_id": org_id,
     }
 

--- a/VCE/gather_devices.py
+++ b/VCE/gather_devices.py
@@ -13,8 +13,8 @@ from os import getenv
 import requests
 from dotenv import load_dotenv
 
-import custom_exceptions
-from verkada_totp import generate_totp
+from QoL.custom_exceptions import APIExceptionHandler
+from QoL.verkada_totp import generate_totp
 
 load_dotenv()  # Load credentials file
 
@@ -105,7 +105,10 @@ def create_thread_with_args(target, args):
 
 
 def login_and_get_tokens(
-    login_session, username=USERNAME, password=PASSWORD, org_id=ORG_ID
+    login_session: requests.Session,
+    username=USERNAME,
+    password=PASSWORD,
+    org_id=ORG_ID,
 ):
     """
     Initiates a Command session with the given user credentials and Verkada
@@ -150,12 +153,15 @@ def login_and_get_tokens(
 
     # Handle exceptions
     except requests.exceptions.RequestException as e:
-        raise custom_exceptions.APIExceptionHandler(
-            e, response, "Login"
-        ) from e
+        raise APIExceptionHandler(e, response, "Login") from e
 
 
-def logout(logout_session, x_verkada_token, x_verkada_auth, org_id=ORG_ID):
+def logout(
+    logout_session: requests.Session,
+    x_verkada_token,
+    x_verkada_auth,
+    org_id=ORG_ID,
+):
     """
     Logs the Python script out of Command to prevent orphaned sessions.
 
@@ -184,9 +190,7 @@ def logout(logout_session, x_verkada_token, x_verkada_auth, org_id=ORG_ID):
 
     # Handle exceptions
     except requests.exceptions.RequestException as e:
-        raise custom_exceptions.APIExceptionHandler(
-            e, response, "Logout"
-        ) from e
+        raise APIExceptionHandler(e, response, "Logout") from e
 
     except KeyboardInterrupt:
         log.warning("Keyboard interrupt detected. Exiting...")
@@ -200,7 +204,7 @@ def logout(logout_session, x_verkada_token, x_verkada_auth, org_id=ORG_ID):
 ##############################################################################
 
 
-def list_cameras(api_key, camera_session):
+def list_cameras(api_key, camera_session: requests.Session):
     """
     Will list all cameras inside of a Verkada organization.
 
@@ -234,13 +238,15 @@ def list_cameras(api_key, camera_session):
 
     # Handle exceptions
     except requests.exceptions.RequestException as e:
-        raise custom_exceptions.APIExceptionHandler(
-            e, response, "Cameras"
-        ) from e
+        raise APIExceptionHandler(e, response, "Cameras") from e
 
 
 def get_sites(
-    x_verkada_token, x_verkada_auth, usr, site_session, org_id=ORG_ID
+    x_verkada_token,
+    x_verkada_auth,
+    usr,
+    site_session: requests.Session,
+    org_id=ORG_ID,
 ):
     """
     Lists all Verkada Guest sites.
@@ -287,12 +293,16 @@ def get_sites(
 
     # Handle exceptions
     except requests.exceptions.RequestException as e:
-        raise custom_exceptions.APIExceptionHandler(
-            e, response, "Sites"
-        ) from e
+        raise APIExceptionHandler(e, response, "Sites") from e
 
 
-def list_ac(x_verkada_token, x_verkada_auth, usr, ac_session, org_id=ORG_ID):
+def list_ac(
+    x_verkada_token,
+    x_verkada_auth,
+    usr,
+    ac_session: requests.Session,
+    org_id=ORG_ID,
+):
     """
     Lists all access control devices.
 
@@ -343,13 +353,15 @@ def list_ac(x_verkada_token, x_verkada_auth, usr, ac_session, org_id=ORG_ID):
 
     # Handle exceptions
     except requests.exceptions.RequestException as e:
-        raise custom_exceptions.APIExceptionHandler(
-            e, response, "Access Control"
-        ) from e
+        raise APIExceptionHandler(e, response, "Access Control") from e
 
 
 def list_alarms(
-    x_verkada_token, x_verkada_auth, usr, alarms_session, org_id=ORG_ID
+    x_verkada_token,
+    x_verkada_auth,
+    usr,
+    alarms_session: requests.Session,
+    org_id=ORG_ID,
 ):
     """
     Lists all alarm devices.
@@ -469,13 +481,15 @@ def list_alarms(
 
     # Handle exceptions
     except requests.exceptions.RequestException as e:
-        raise custom_exceptions.APIExceptionHandler(
-            e, response, "Alarms"
-        ) from e
+        raise APIExceptionHandler(e, response, "Alarms") from e
 
 
 def list_viewing_stations(
-    x_verkada_token, x_verkada_auth, usr, vx_session, org_id=ORG_ID
+    x_verkada_token,
+    x_verkada_auth,
+    usr,
+    vx_session: requests.Session,
+    org_id=ORG_ID,
 ):
     """
     Lists all viewing stations.
@@ -527,13 +541,15 @@ def list_viewing_stations(
 
     # Handle exceptions
     except requests.exceptions.RequestException as e:
-        raise custom_exceptions.APIExceptionHandler(
-            e, response, "Viewing Stations"
-        ) from e
+        raise APIExceptionHandler(e, response, "Viewing Stations") from e
 
 
 def list_gateways(
-    x_verkada_token, x_verkada_auth, usr, gc_session, org_id=ORG_ID
+    x_verkada_token,
+    x_verkada_auth,
+    usr,
+    gc_session: requests.Session,
+    org_id=ORG_ID,
 ):
     """
     Lists all cellular gateways.
@@ -584,13 +600,15 @@ def list_gateways(
 
     # Handle exceptions
     except requests.exceptions.RequestException as e:
-        raise custom_exceptions.APIExceptionHandler(
-            e, response, "Cellular Gateways"
-        ) from e
+        raise APIExceptionHandler(e, response, "Cellular Gateways") from e
 
 
 def list_sensors(
-    x_verkada_token, x_verkada_auth, usr, sv_session, org_id=ORG_ID
+    x_verkada_token,
+    x_verkada_auth,
+    usr,
+    sv_session: requests.Session,
+    org_id=ORG_ID,
 ):
     """
     Lists all environmental sensors.
@@ -641,13 +659,15 @@ def list_sensors(
 
     # Handle exceptions
     except requests.exceptions.RequestException as e:
-        raise custom_exceptions.APIExceptionHandler(
-            e, response, "Environmental Sensors"
-        ) from e
+        raise APIExceptionHandler(e, response, "Environmental Sensors") from e
 
 
 def list_horns(
-    x_verkada_token, x_verkada_auth, usr, bz_session, org_id=ORG_ID
+    x_verkada_token,
+    x_verkada_auth,
+    usr,
+    bz_session: requests.Session,
+    org_id=ORG_ID,
 ):
     """
     Lists all BZ horn speakers.
@@ -696,12 +716,12 @@ def list_horns(
 
     # Handle exceptions
     except requests.exceptions.RequestException as e:
-        raise custom_exceptions.APIExceptionHandler(
-            e, response, "BZ11 Horn Speakers"
-        ) from e
+        raise APIExceptionHandler(e, response, "BZ11 Horn Speakers") from e
 
 
-def list_desk_stations(x_verkada_token, usr, ds_session, org_id=ORG_ID):
+def list_desk_stations(
+    x_verkada_token, usr, ds_session: requests.Session, org_id=ORG_ID
+):
     """
     Lists all desk stations.
 
@@ -744,16 +764,14 @@ def list_desk_stations(x_verkada_token, usr, ds_session, org_id=ORG_ID):
 
     # Handle exceptions
     except requests.exceptions.RequestException as e:
-        raise custom_exceptions.APIExceptionHandler(
-            e, response, "Desk Stations"
-        ) from e
+        raise APIExceptionHandler(e, response, "Desk Stations") from e
 
 
 def list_guest(
     x_verkada_token,
     x_verkada_auth,
     usr,
-    guest_session,
+    guest_session: requests.Session,
     org_id=ORG_ID,
     sites=None,
 ):
@@ -828,12 +846,12 @@ def list_guest(
 
     # Handle exceptions
     except requests.exceptions.RequestException as e:
-        raise custom_exceptions.APIExceptionHandler(
-            e, response, "Sites"
-        ) from e
+        raise APIExceptionHandler(e, response, "Sites") from e
 
 
-def list_acls(x_verkada_token, usr, acl_session, org_id=ORG_ID):
+def list_acls(
+    x_verkada_token, usr, acl_session: requests.Session, org_id=ORG_ID
+):
     """
     Lists all access control levels.
 
@@ -874,9 +892,7 @@ def list_acls(x_verkada_token, usr, acl_session, org_id=ORG_ID):
 
     # Handle exceptions
     except requests.exceptions.RequestException as e:
-        raise custom_exceptions.APIExceptionHandler(
-            e, response, "Sites"
-        ) from e
+        raise APIExceptionHandler(e, response, "Sites") from e
 
 
 ##############################################################################


### PR DESCRIPTION
# Explicit Declaration of `requests.Session`

## Description

Explicitly defining `requests.Session` for all functions to avoid the following error:
```
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1010, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/ray.kman/Documents/VCE_Automation/API_Scripts/VCE/delete_device.py", line 850, in delete_desk_station
    if ds_ids := gather_devices.list_desk_stations(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ray.kman/Documents/VCE_Automation/API_Scripts/VCE/gather_devices.py", line 732, in list_desk_stations
    response = ds_session.get(DESK_URL, headers=headers)
               ^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'get'
```

Fixes #24 & #26

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the [style guidelines](https://github.com/ian-young/API_Scripts/blob/main/Wiki/Development.md#style-guides-and-best-practices) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug where a 'str' object was incorrectly used as a session object, causing an AttributeError. The fix involves explicitly defining `requests.Session` for all relevant functions. Additionally, type annotations for `requests.Session` have been added to function parameters to enhance code clarity and type safety.

- **Bug Fixes**:
    - Fixed AttributeError by explicitly defining `requests.Session` for all functions to ensure proper session handling.
- **Enhancements**:
    - Added type annotations for `requests.Session` in function parameters to improve code clarity and type safety.

<!-- Generated by sourcery-ai[bot]: end summary -->